### PR TITLE
wrap std::tolower when using it in std::transform

### DIFF
--- a/src/common/FilterMatcher.cpp
+++ b/src/common/FilterMatcher.cpp
@@ -9,7 +9,7 @@ FilterMatcher::FilterMatcher(const Filter& filter) :
 
     if (!filter.matchCase)
     {
-        std::transform(expression.begin(), expression.end(), expression.begin(), std::tolower);
+        std::transform(expression.begin(), expression.end(), expression.begin(), [](unsigned char c){ return std::tolower(c); });
     }
 
     if (filter.regex)

--- a/src/widgets/views/StructList.cpp
+++ b/src/widgets/views/StructList.cpp
@@ -16,7 +16,7 @@ StructList::StructList(const dots::type::StructDescriptor<>& descriptor, const P
     m_structDescriptorModel{ descriptor },
     m_publisherModel{ publisherModel }
 {
-    std::transform(descriptor.name().begin(), descriptor.name().end(), std::back_inserter(m_typeNameLower), std::tolower);
+    std::transform(descriptor.name().begin(), descriptor.name().end(), std::back_inserter(m_typeNameLower), [](unsigned char c){ return std::tolower(c); });
 
     const auto& propertyPaths = descriptor.propertyPaths();
 

--- a/src/widgets/views/TraceItem.cpp
+++ b/src/widgets/views/TraceItem.cpp
@@ -93,7 +93,7 @@ void TraceItem::setFilterTargets(const FilterTargets& targets)
     }
 
     m_filterTextLower.clear();
-    std::transform(m_filterText.begin(), m_filterText.end(), std::back_inserter(m_filterTextLower), std::tolower);
+    std::transform(m_filterText.begin(), m_filterText.end(), std::back_inserter(m_filterTextLower), [](unsigned char c){ return std::tolower(c); });
 }
 
 bool TraceItem::isFiltered(const std::optional<FilterMatcher>& filter, const FilterSettings& filterSettings) const


### PR DESCRIPTION
Since they are defined with integer parameters, std::tolower and other
functions from the cctype header cannot (and should not) be used
directly with STL algorithms and must instead be wrapped (see [1]).

References:

 - [1] https://en.cppreference.com/w/cpp/string/byte/tolower