### PR TITLE
Fix record-view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ add_executable(${TARGET_NAME})
 target_dots_model(${TARGET_NAME}
     src/common/Settings.dots
     src/common/Version.dots
+    src/dots_ext/dots_record.dots
 )
 target_sources(${TARGET_NAME}
     PRIVATE

--- a/src/dots_ext/FileInChannel.cpp
+++ b/src/dots_ext/FileInChannel.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <dots/asio.h>
 #include <dots/HostTransceiver.h>
+#include <DotsRecordHeader.dots.h>
 
 namespace dots::io::details
 {
@@ -13,6 +14,10 @@ namespace dots::io::details
         m_ioContext{ ioContext },
         m_path{ std::move(path) }
     {
+        if (m_fileRegistry.findType("DotsRecordHeader") == nullptr)
+        {
+            m_fileRegistry.registerType(dots::type::Descriptor<DotsRecordHeader>::Instance());
+        }
         loadFile();
     }
 

--- a/src/dots_ext/FileInChannel.cpp
+++ b/src/dots_ext/FileInChannel.cpp
@@ -3,20 +3,19 @@
 #include <fstream>
 #include <dots/asio.h>
 #include <dots/HostTransceiver.h>
-#include <DotsRecordHeader.dots.h>
 
 namespace dots::io::details
 {
-    GenericFileInChannel::GenericFileInChannel(key_t key, asio::io_context& ioContext, std::filesystem::path path) :
+    GenericFileInChannel::GenericFileInChannel(key_t key, asio::io_context& ioContext, std::filesystem::path path, const std::vector<type::Descriptor<>*>& preregister_descriptors) :
         LocalChannel(key, ioContext),
         m_fileRegistry{ std::nullopt, type::Registry::StaticTypePolicy::InternalOnly },
         m_transmissionsRead(0),
         m_ioContext{ ioContext },
         m_path{ std::move(path) }
     {
-        if (m_fileRegistry.findType("DotsRecordHeader") == nullptr)
+        for (auto* descriptor : preregister_descriptors)
         {
-            m_fileRegistry.registerType(dots::type::Descriptor<DotsRecordHeader>::Instance());
+            m_fileRegistry.registerType(*descriptor, false);
         }
         loadFile();
     }

--- a/src/dots_ext/FileInChannel.h
+++ b/src/dots_ext/FileInChannel.h
@@ -10,7 +10,7 @@ namespace dots::io::details
 {
     struct GenericFileInChannel : LocalChannel
     {
-        GenericFileInChannel(key_t key, asio::io_context& ioContext, std::filesystem::path path);
+        GenericFileInChannel(key_t key, asio::io_context& ioContext, std::filesystem::path path, const std::vector<type::Descriptor<>*> &preregister_descriptors = {});
         GenericFileInChannel(const GenericFileInChannel& other) = delete;
         GenericFileInChannel(GenericFileInChannel&& other) = delete;
         ~GenericFileInChannel() override = default;

--- a/src/dots_ext/dots_record.dots
+++ b/src/dots_ext/dots_record.dots
@@ -1,0 +1,7 @@
+
+struct DotsRecordHeader [cached=false] {
+    1: [key] string name;
+    2: timepoint startTime;
+    3: vector<string> whitelist;
+}
+

--- a/src/widgets/views/HostView.cpp
+++ b/src/widgets/views/HostView.cpp
@@ -9,6 +9,7 @@
 #include <common/Settings.h>
 #include <common/System.h>
 #include <DotsDescriptorRequest.dots.h>
+#include <DotsCacheInfo.dots.h>
 
 HostView::HostView(std::string appName) :
     m_state(State::Disconnected),
@@ -414,6 +415,11 @@ void HostView::update()
                     dots::type::Registry::StaticTypePolicy::InternalOnly,
                     transition_handler_t{ &HostView::handleTransceiverTransition, this }
                 );
+
+                if (dots::global_transceiver()->registry().findType("DotsCacheInfo") == nullptr)
+                {
+                    dots::global_transceiver()->registry().registerType(dots::type::Descriptor<DotsCacheInfo>::Instance());
+                }
 
                 dots::io::Endpoint endpoint{ *m_hostSettings.activeHost->endpoint };
 

--- a/src/widgets/views/HostView.cpp
+++ b/src/widgets/views/HostView.cpp
@@ -10,6 +10,7 @@
 #include <common/System.h>
 #include <DotsDescriptorRequest.dots.h>
 #include <DotsCacheInfo.dots.h>
+#include "DotsRecordHeader.dots.h"
 
 HostView::HostView(std::string appName) :
     m_state(State::Disconnected),
@@ -430,7 +431,25 @@ void HostView::update()
                     if (path.front() == '/')
                         path.remove_prefix(1);
                     #endif
-                    transceiver.open<dots::io::FileInChannel>(path);
+
+
+                    /*
+                     * Pre-register DotsRecordHeader as workaround for broken dots-record files.
+                     *
+                     * In the past, DotsRecordHeader was an 'internal'-flagged DOTS-type. Later the
+                     * definition moved from DOTS library to the dots-record tool, but without
+                     * removing the 'internal'-flag.
+                     * The consequence is, that applications like this, do not know DotsRecordHeader,
+                     * but it is also not exported to the record-file because of the 'internal'-flag.
+                     * Without preregistering the DOTS type 'DotsRecordHeader', this application
+                     * cannot resolve the missing type.
+                     */
+                    std::vector<dots::type::Descriptor<>*> preregister_descriptors {
+                        &dots::type::Descriptor<DotsRecordHeader>::Instance()
+                    };
+
+                    transceiver.open<dots::io::FileInChannel>(path, preregister_descriptors);
+
                 }
                 else
                     transceiver.open(endpoint);


### PR DESCRIPTION
dots-explorer was unable to open record files, due to missing DotsCacheClient Descriptor and a bug that occures when skipping objects in a DOTS object stream in DOTS.